### PR TITLE
Refactor into functions for easier development, documentation, testing and reuse.

### DIFF
--- a/.idea/Pub-Grab.iml
+++ b/.idea/Pub-Grab.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="projectConfiguration" value="Nosetests" />
+    <option name="PROJECT_TEST_RUNNER" value="Nosetests" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Project Default" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.5.1 (C:\Miniconda3\envs\cgpdev\python.exe)" project-jdk-type="Python SDK" />
+  <component name="masterDetails">
+    <states>
+      <state key="ScopeChooserConfigurable.UI">
+        <settings>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Pub-Grab.iml" filepath="$PROJECT_DIR$/.idea/Pub-Grab.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -15,15 +15,6 @@ Info on transition from old to new API: http://www.cristin.no/om/aktuelt/aktuell
 import requests
 from urllib.parse import urlencode
 
-# set up which user to search for will be passed to an ARGV in the future
-# To be added later start year and end year
-# start_year = 2015 end_year = 2015
-name_of_user = "Jon Olav Vik"
-# name_of_user = "Dag Inge Våge"
-# name_of_user = "Sigbjørn Lien"
-# name_of_user = "Arne Bjørke Gjuvsland"
-
-
 def cristin_person_id(author):
     """
     Get CRISTIN person ID of author.
@@ -70,97 +61,106 @@ def pubs_by(author):
     return pubs
 
 
-# Initiate the url using pubs_by
-data = pubs_by(name_of_user)
+if __name__ == "__main__":
+    # set up which user to search for will be passed to an ARGV in the future
+    # To be added later start year and end year
+    # start_year = 2015 end_year = 2015
+    name_of_user = "Jon Olav Vik"
+    # name_of_user = "Dag Inge Våge"
+    # name_of_user = "Sigbjørn Lien"
+    # name_of_user = "Arne Bjørke Gjuvsland"
 
-# Create a list containing all information for printing html code
-html_codes_all = []
+    # Initiate the url using pubs_by
+    data = pubs_by(name_of_user)
 
-# Sort data according to year of publication, newest first
-# noinspection PyShadowingNames
-data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'], reverse=True)
-# Start to iterate through all the "forskningsresultat" list
-for i in data_sort:
-    # Create a string for name for each iteration
-    authors = ''
-    # Iterate through all persons in the project and create a name list
-    # Some instances are lists when multiple authors
-    if type(i['fellesdata']['person']) == list:
-        for k in i['fellesdata']['person']:
-            # Convert first names to uppercase letters only
-            Short_firstname = k['fornavn']
+    # Create a list containing all information for printing html code
+    html_codes_all = []
+
+    # Sort data according to year of publication, newest first
+    # noinspection PyShadowingNames
+    data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'], reverse=True)
+    # Start to iterate through all the "forskningsresultat" list
+    for i in data_sort:
+        # Create a string for name for each iteration
+        authors = ''
+        # Iterate through all persons in the project and create a name list
+        # Some instances are lists when multiple authors
+        if type(i['fellesdata']['person']) == list:
+            for k in i['fellesdata']['person']:
+                # Convert first names to uppercase letters only
+                Short_firstname = k['fornavn']
+                Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
+                # Append all the names to a string
+                authors += ((k['etternavn'] + ' ' + Uppercase_firstname) + ', ')
+            # Remove a comma and a white space at the end of strings
+            authors = authors[:-2]
+
+        # For instances when there is a single author
+        elif type(i['fellesdata']['person']) == dict:
+            Short_firstname = i['fellesdata']['person']['fornavn']
             Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
-            # Append all the names to a string
-            authors += ((k['etternavn'] + ' ' + Uppercase_firstname) + ', ')
-        # Remove a comma and a white space at the end of strings
-        authors = authors[:-2]
+            # Append name to a string
+            authors = i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname
 
-    # For instances when there is a single author
-    elif type(i['fellesdata']['person']) == dict:
-        Short_firstname = i['fellesdata']['person']['fornavn']
-        Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
-        # Append name to a string
-        authors = i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname
+        # Iterate through all keys in the categories.
+        for key, value in (i['kategoridata']).items():
+            # Start processing data based on known keys. This will be expanded later
+            if key == 'tidsskriftsartikkel':
+                tittel = i['fellesdata']['tittel']
+                year = i['fellesdata']['ar']
+                journal = '<em>' + i['kategoridata']['tidsskriftsartikkel']['tidsskrift']['navn'] + '</em>'
 
-    # Iterate through all keys in the categories.
-    for key, value in (i['kategoridata']).items():
-        # Start processing data based on known keys. This will be expanded later
-        if key == 'tidsskriftsartikkel':
-            tittel = i['fellesdata']['tittel']
-            year = i['fellesdata']['ar']
-            journal = '<em>' + i['kategoridata']['tidsskriftsartikkel']['tidsskrift']['navn'] + '</em>'
+                try:
+                    articlenr = i['kategoridata']['tidsskriftsartikkel']['artikkelnr']
+                except KeyError:
+                    articlenr = ''
 
-            try:
-                articlenr = i['kategoridata']['tidsskriftsartikkel']['artikkelnr']
-            except KeyError:
-                articlenr = ''
+                try:
+                    volum = '<strong>(' + i['kategoridata']['tidsskriftsartikkel']['volum'] + ')</strong>'
+                except KeyError:
+                    volum = ''
 
-            try:
-                volum = '<strong>(' + i['kategoridata']['tidsskriftsartikkel']['volum'] + ')</strong>'
-            except KeyError:
-                volum = ''
+                try:
+                    DOI = 'http://dx.doi.org/' + i['kategoridata']['tidsskriftsartikkel']['doi']
+                except KeyError:
+                    DOI = ''
 
-            try:
-                DOI = 'http://dx.doi.org/' + i['kategoridata']['tidsskriftsartikkel']['doi']
-            except KeyError:
-                DOI = ''
+                HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum +
+                               ' ' + articlenr + ' ' + DOI + '</p>')
+                html_codes_all.append(HTML_string)
 
-            HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum +
-                           ' ' + articlenr + ' ' + DOI + '</p>')
-            html_codes_all.append(HTML_string)
+                # Currently only working for Articles, codes below can be used to add more items.
+                # elif key == ( 'foredragPoster' ):
+                #     tittel = i['fellesdata']['tittel']
+                #     year = i['fellesdata']['ar']
+                #     #journal = '<em>'+i['kategoridata'][key]['navn']+'</em>' Wrokshop
+                # elif key == 'bokRapport':
+                #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
+                #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
+                #
+                # elif key == 'bokRapportDel':
+                #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
+                #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
 
-            # Currently only working for Articles, codes below can be used to add more items.
-            # elif key == ( 'foredragPoster' ):
-            #     tittel = i['fellesdata']['tittel']
-            #     year = i['fellesdata']['ar']
-            #     #journal = '<em>'+i['kategoridata'][key]['navn']+'</em>' Wrokshop
-            # elif key == 'bokRapport':
-            #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-            #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
-            #
-            # elif key == 'bokRapportDel':
-            #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-            #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
+    html_str_start = """
+    <!DOCTYPE html>
+    <HTML>
+        <head>
+            <meta charset="utf-8">
+        </head>
 
-html_str_start = """
-<!DOCTYPE html>
-<HTML>
-    <head>
-        <meta charset="utf-8">
-    </head>
+        <body>
+            <h1>References</h1>
+    """
 
-    <body>
-        <h1>References</h1>
-"""
+    html_str_end = """
+        </body>
+    </HTML>
+    """
 
-html_str_end = """
-    </body>
-</HTML>
-"""
-
-filename = name_of_user + '.html'
-with open(filename, 'w+', encoding="utf-8") as myFile:
-    myFile.write(html_str_start)
-    for i in html_codes_all:
-        myFile.write('\t\t' + i + '\n')
-    myFile.write(html_str_end)
+    filename = name_of_user + '.html'
+    with open(filename, 'w+', encoding="utf-8") as myFile:
+        myFile.write(html_str_start)
+        for i in html_codes_all:
+            myFile.write('\t\t' + i + '\n')
+        myFile.write(html_str_end)

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -40,7 +40,7 @@ def cristin_person_id(author):
             return None
 
 
-def pubs_by(author):
+def pubs_by(author, fromyear="", toyear=""):
     """
     Get publications by author.
 
@@ -55,7 +55,7 @@ def pubs_by(author):
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"
-    url = base + urlencode(dict(lopenr=cpid, fra=2002, til=2016, format="json"))
+    url = base + urlencode(dict(lopenr=cpid, fra=fromyear, til=toyear, format="json"))
     print(url)
     pubs = requests.get(url).json()
     return pubs

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -48,45 +48,120 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
     For now we return the full record, whose complex structure is documented at
     http://www.cristin.no/techdoc/xsd/resultater/1.0/
 
-    >>> from pprint import pprint
-    >>> pprint(pubs_by("Jon Olav Vik", 2009, 2009))
+    Example search that returns a single publication.
+
+    >>> from pprint import pprint  # Deterministic printing of dict (recursively sorts items)
+    >>> p = pubs_by("Jon Olav Vik", 2014, 2014)
+    >>> len(p["forskningsresultat"])
+    1
+    >>> len(pubs_by("Jon Olav Vik", fra=1900, til=2015)["forskningsresultat"])
+    29
+    >>> sorted(p["forskningsresultat"][0].keys())
+    ['fellesdata', 'kategoridata']
+    >>> pprint(p)
     {...
-     'forskningsresultat': [{'fellesdata': {'ar': '2009',
+     'forskningsresultat': [{'fellesdata': {'ar': '2014',
                                             ...
-                                            'id': '355297',
+                                            'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
+                                                                 'id': 'SKGJ-MED-005'},
+                                                                {'finansieringskilde': {'kode': 'NFR', ...},
+                                                                 'id': '178901'},
+                                                                {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
+                                                                 'id': 'NN4653K'}],
                                             ...
-                                            'person': [{'etternavn': 'Godvik',
-                                                        'fornavn': 'Inger Maren '
-                                                                   'Rivrud',
+                                            'id': '1161735',
+                                            ...
+                                            'person': [{'etternavn': 'Nordbø',
+                                                        'fornavn': 'Øyvind',
                                                         ...
-                                                        'id': '5361',
+                                                        'id': '317719',
                                                         'rekkefolgenr': '1',
-                                                        'tilhorighet': [{'sted': {'avdnr': '15', ...]},
-                                                       {'etternavn': 'Loe', ...},
-                                                       {'etternavn': 'Vik', ...},
-                                                       {'etternavn': 'Veiberg', ...},
-                                                       {'etternavn': 'Langvatn', ...},
-                                                       {'etternavn': 'Mysterud', ...}],
+                                                        'tilhorighet': {'sted': {'avdnr': '1', ...]},
+                                                       ...
+                                                       {'etternavn': 'Vik', ...}],
                                             ...
-                                            'tittel': 'Temporal scales, '
-                                                      'trade-offs, and functional '
-                                                      'responses in red deer '
-                                                      'habitat selection'},
-                             'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1890/08-0576.1',
-                                                                      'hefte': '3',
-                                                                      'sideangivelse': {'sideFra': '699',
-                                                                                        'sideTil': '710'},
-                                                                      'tidsskrift': {'id': '185',
-                                                                                     'issn': '0012-9658',
-                                                                                     'kvalitetsniva': {'kode': '2',
-                                                                                                       'navn': 'Kvalitetsnivå '
-                                                                                                               '2',
-                                                                                                       'navnEngelsk': 'Quality '
-                                                                                                                      'level '
-                                                                                                                      '2'},
-                                                                                     'navn': 'Ecology', ...},
-                                                                      'volum': '90'}}}],
-     ...}
+                                            'sammendrag': {'sprak': {...},
+                                                           'tekst': 'The mouse is '
+                                                                    'an important '
+                                                                    ...
+                                                                    'application.'},
+                                            ...
+                                            'tittel': 'A computational pipeline '
+                                                      'for quantification of mouse '
+                                                      'myocardial stiffness '
+                                                      'parameters'},
+                             'kategoridata': {'tidsskriftsartikkel': {'arstallOnline': '2014',
+                                                                      'arstallTrykket': '2014',
+                                                                      'doi': '10.1016/j.compbiomed.2014.07.013',
+                                                                      'sideangivelse': {'sideFra': '65',
+                                                                                        'sideTil': '75'},
+                                                                      'tidsskrift': {'id': '18057',
+                                                                                     'issn': '0010-4825',
+                                                                                     'kvalitetsniva': {'kode': '1',
+                                                                                                       ...},
+                                                                                     'navn': 'Computers '
+                                                                                             'in '
+                                                                                             'Biology '
+                                                                                             'and '
+                                                                                             'Medicine',
+                                                                                     ...},
+                                                                      'volum': '53'}}}],
+    ...}
+
+    Example search with two publications.
+
+    >>> p = pubs_by("Arne Gjuvsland", 2010, 2010)
+    >>> len(p["forskningsresultat"])
+    2
+    >>> sorted(p["forskningsresultat"][0].keys())
+    ['fellesdata', 'kategoridata']
+    >>> pprint(p)
+    {...
+     'forskningsresultat': [{'fellesdata': {...
+                                            'ar': '2010',
+                                            ...
+                                            'id': '769189',
+                                            ...
+                                            'person': [{'etternavn': 'Gjuvsland', ...},
+                                                       {'etternavn': 'Plahte', ...},
+                                                       {'etternavn': 'Ådnøy', ...},
+                                                       {'etternavn': 'Omholt', ...}],
+                                            ...
+                                            'tittel': 'Allele Interaction - Single '
+                                                      'Locus Genetics Meets '
+                                                      'Regulatory Biology'},
+                             'kategoridata': {'tidsskriftsartikkel': {'artikkelnr': 'e9379',
+                                                                      'doi': '10.1371/journal.pone.0009379',
+                                                                      'hefte': '2',
+                                                                      'tidsskrift': {'@oaDoaj': 'true',
+                                                                                     ...
+                                                                                     'navn': 'PLoS '
+                                                                                             'ONE',
+                                                                                     ...},
+                                                                      'volum': '5'}}},
+                            {'fellesdata': {...
+                                            'ar': '2010',
+                                            ...
+                                            'id': '771116',
+                                            ...
+                                            'person': [{'etternavn': 'Tøndel', ...},
+                                                       {'etternavn': 'Gjuvsland', ...},
+                                                       ...],
+                                            ...
+                                            'tittel': 'Screening design for '
+                                                      'computer experiments: '
+                                            ...},
+                             'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1002/cem.1363',
+                                                                      'hefte': '11-12',
+                                                                      'sideangivelse': {'sideFra': '738',
+                                                                                        'sideTil': '747'},
+                                                                      'tidsskrift': {...
+                                                                                     'navn': 'Journal '
+                                                                                             'of '
+                                                                                             'Chemometrics',
+                                                                                     ...},
+                                                                      'volum': '24'}}}],
+    ...}
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -74,32 +74,32 @@ html_codes_all = []
 
 # Sort data according to year of publication, newest first
 data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'],reverse=True)
-# Start to itterate throguh all the "forskningsresultat" list
+# Start to iterate through all the "forskningsresultat" list
 for i in data_sort:
-    # Create a string for name for each itteration
-    authers = ''
+    # Create a string for name for each iteration
+    authors = ''
     # Iterate through all persons in the project and create a name list
-    # Some instances are lists when multiple authers
+    # Some instances are lists when multiple authors
     if (type(i['fellesdata']['person']) == list ):
         for k in i['fellesdata']['person']:
             # Convert first names to uppercase letters only
             Short_firstname = k['fornavn']
             Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
             # Append all the names to a string
-            authers += ((k['etternavn'] + ' ' + Uppercase_firstname) + ', ')
+            authors += ((k['etternavn'] + ' ' + Uppercase_firstname) + ', ')
         # Remove a comma and a white space at the end of strings
-        authers = authers[:-2]
+        authors = authors[:-2]
 
-    # For instances when its a single auther
+    # For instances when there is a single author
     elif (type(i['fellesdata']['person']) == dict ):
         Short_firstname = i['fellesdata']['person']['fornavn']
         Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
         # Append name to a string
-        authers = ((i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname))
+        authors = ((i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname))
         
-    # Iterate through all keys in the katergories.
+    # Iterate through all keys in the categories.
     for key, value in (i['kategoridata']).items():
-        # Start prasing data based on known keys. This will be expanded later
+        # Start processing data based on known keys. This will be expanded later
         if key == 'tidsskriftsartikkel':
             tittel = i['fellesdata']['tittel']
             year = i['fellesdata']['ar']
@@ -120,10 +120,10 @@ for i in data_sort:
             except KeyError:
                  DOI = ''
 
-            HTML_string = ('<p> ' + authers + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum + ' ' + articlenr + ' ' + DOI + '</p>')
+            HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum + ' ' + articlenr + ' ' + DOI + '</p>')
             html_codes_all.append(HTML_string)
 
-        # Corrently only working for Articles, codes below can be used to add more items.
+        # Currently only working for Articles, codes below can be used to add more items.
         # elif key == ( 'foredragPoster' ):
         #     tittel = i['fellesdata']['tittel']
         #     year = i['fellesdata']['ar']

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -19,13 +19,15 @@ from urllib.parse import urlencode
 # To be added later start year and end year
 # start_year = 2015 end_year = 2015
 name_of_user = "Jon Olav Vik"
-#name_of_user = "Dag Inge Våge"
-#name_of_user = "Sigbjørn Lien"
-#name_of_user = "Arne Bjørke Gjuvsland"
+# name_of_user = "Dag Inge Våge"
+# name_of_user = "Sigbjørn Lien"
+# name_of_user = "Arne Bjørke Gjuvsland"
+
 
 def cristin_person_id(author):
     """
     Get CRISTIN person ID of author.
+
     >>> cristin_person_id("Jon Olav Vik")
     22311
     >>> cristin_person_id("22311")
@@ -45,6 +47,7 @@ def cristin_person_id(author):
             return person[0]["cristin_person_id"]
         else:
             return None
+
 
 def pubs_by(author):
     """
@@ -66,6 +69,7 @@ def pubs_by(author):
     pubs = requests.get(url).json()
     return pubs
 
+
 # Initiate the url using pubs_by
 data = pubs_by(name_of_user)
 
@@ -73,14 +77,15 @@ data = pubs_by(name_of_user)
 html_codes_all = []
 
 # Sort data according to year of publication, newest first
-data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'],reverse=True)
+# noinspection PyShadowingNames
+data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'], reverse=True)
 # Start to iterate through all the "forskningsresultat" list
 for i in data_sort:
     # Create a string for name for each iteration
     authors = ''
     # Iterate through all persons in the project and create a name list
     # Some instances are lists when multiple authors
-    if (type(i['fellesdata']['person']) == list ):
+    if type(i['fellesdata']['person']) == list:
         for k in i['fellesdata']['person']:
             # Convert first names to uppercase letters only
             Short_firstname = k['fornavn']
@@ -91,19 +96,19 @@ for i in data_sort:
         authors = authors[:-2]
 
     # For instances when there is a single author
-    elif (type(i['fellesdata']['person']) == dict ):
+    elif type(i['fellesdata']['person']) == dict:
         Short_firstname = i['fellesdata']['person']['fornavn']
         Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
         # Append name to a string
-        authors = ((i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname))
-        
+        authors = i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname
+
     # Iterate through all keys in the categories.
     for key, value in (i['kategoridata']).items():
         # Start processing data based on known keys. This will be expanded later
         if key == 'tidsskriftsartikkel':
             tittel = i['fellesdata']['tittel']
             year = i['fellesdata']['ar']
-            journal = '<em>'+i['kategoridata']['tidsskriftsartikkel']['tidsskrift']['navn']+'</em>'
+            journal = '<em>' + i['kategoridata']['tidsskriftsartikkel']['tidsskrift']['navn'] + '</em>'
 
             try:
                 articlenr = i['kategoridata']['tidsskriftsartikkel']['artikkelnr']
@@ -116,25 +121,26 @@ for i in data_sort:
                 volum = ''
 
             try:
-                 DOI = 'http://dx.doi.org/' + i['kategoridata']['tidsskriftsartikkel']['doi']
+                DOI = 'http://dx.doi.org/' + i['kategoridata']['tidsskriftsartikkel']['doi']
             except KeyError:
-                 DOI = ''
+                DOI = ''
 
-            HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum + ' ' + articlenr + ' ' + DOI + '</p>')
+            HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum +
+                           ' ' + articlenr + ' ' + DOI + '</p>')
             html_codes_all.append(HTML_string)
 
-        # Currently only working for Articles, codes below can be used to add more items.
-        # elif key == ( 'foredragPoster' ):
-        #     tittel = i['fellesdata']['tittel']
-        #     year = i['fellesdata']['ar']
-        #     #journal = '<em>'+i['kategoridata'][key]['navn']+'</em>' Wrokshop
-        # elif key == 'bokRapport':
-        #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-        #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
-        #
-        # elif key == 'bokRapportDel':
-        #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-        #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
+            # Currently only working for Articles, codes below can be used to add more items.
+            # elif key == ( 'foredragPoster' ):
+            #     tittel = i['fellesdata']['tittel']
+            #     year = i['fellesdata']['ar']
+            #     #journal = '<em>'+i['kategoridata'][key]['navn']+'</em>' Wrokshop
+            # elif key == 'bokRapport':
+            #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
+            #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
+            #
+            # elif key == 'bokRapportDel':
+            #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
+            #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
 
 html_str_start = """
 <!DOCTYPE html>
@@ -152,9 +158,9 @@ html_str_end = """
 </HTML>
 """
 
-filename = name_of_user+'.html'
-with open(filename, 'w+',encoding="utf-8") as myFile:
+filename = name_of_user + '.html'
+with open(filename, 'w+', encoding="utf-8") as myFile:
     myFile.write(html_str_start)
     for i in html_codes_all:
-        myFile.write('\t\t'+i+'\n')
+        myFile.write('\t\t' + i + '\n')
     myFile.write(html_str_end)

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -55,90 +55,89 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
     Arne Gjuvsland published two journal articles in 2010.
 
     >>> p = pubs_by("Arne Gjuvsland", 2010, 2010)
-    >>> len(p["forskningsresultat"])
+    >>> len(p)
     2
 
     Each item has "fellesdata" (shared among all publication types) and "kategoridata" (particular to journal articles).
     Both are of interest.
 
-    >>> sorted(p["forskningsresultat"][0].keys())
+    >>> sorted(p[0].keys())
     ['fellesdata', 'kategoridata']
     >>> pprint(p)
-    {...
-     'forskningsresultat': [{'fellesdata': {...
-                                            'ar': '2010',
-                                            ...
-                                            'id': '769189',
-                                            ...
-                                            'person': [{'etternavn': 'Gjuvsland', ...},
-                                                       {'etternavn': 'Plahte', ...},
-                                                       {'etternavn': 'Ådnøy', ...},
-                                                       {'etternavn': 'Omholt', ...}],
-                                            ...
-                                            'tittel': 'Allele Interaction - Single '
-                                                      'Locus Genetics Meets '
-                                                      'Regulatory Biology'},
-                             'kategoridata': {'tidsskriftsartikkel': {'artikkelnr': 'e9379',
-                                                                      'doi': '10.1371/journal.pone.0009379',
-                                                                      'hefte': '2',
-                                                                      'tidsskrift': {'@oaDoaj': 'true',
-                                                                                     ...
-                                                                                     'navn': 'PLoS '
-                                                                                             'ONE',
-                                                                                     ...},
-                                                                      'volum': '5'}}},
-                            {'fellesdata': {...
-                                            'ar': '2010',
-                                            ...
-                                            'id': '771116',
-                                            ...
-                                            'person': [{'etternavn': 'Tøndel',
-                                                        'fornavn': 'Kristin', ...},
-                                                       {'etternavn': 'Gjuvsland', ...},
-                                                       ...],
-                                            ...
-                                            'tittel': 'Screening design for '
-                                                      'computer experiments: '
-                                            ...},
-                             'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1002/cem.1363',
-                                                                      'hefte': '11-12',
-                                                                      'sideangivelse': {'sideFra': '738',
-                                                                                        'sideTil': '747'},
-                                                                      'tidsskrift': {...
-                                                                                     'navn': 'Journal '
-                                                                                             'of '
-                                                                                             'Chemometrics',
-                                                                                     ...},
-                                                                      'volum': '24'}}}],
-    ...}
+    [{'fellesdata': {...
+                     'ar': '2010',
+                     ...
+                     'id': '769189',
+                     ...
+                     'person': [{'etternavn': 'Gjuvsland',
+                                 'fornavn': 'Arne Bjørke', ...},
+                                {'etternavn': 'Plahte', ...},
+                                {'etternavn': 'Ådnøy', ...},
+                                {'etternavn': 'Omholt', ...}],
+                     ...
+                     'tittel': 'Allele Interaction - Single Locus Genetics Meets '
+                               'Regulatory Biology'},
+      'kategoridata': {'tidsskriftsartikkel': {'artikkelnr': 'e9379',
+                                               'doi': '10.1371/journal.pone.0009379',
+                                               'hefte': '2',
+                                               'tidsskrift': {'@oaDoaj': 'true',
+                                                              'id': '435449',
+                                                              'issn': '1932-6203',
+                                                              'kvalitetsniva': {'kode': '1', ...},
+                                                              'navn': 'PLoS ONE',
+                                                              ...},
+                                               'volum': '5'}}},
+     {'fellesdata': {...
+                     'ar': '2010',
+                     ...
+                     'id': '771116',
+                     ...
+                     'person': [{'etternavn': 'Tøndel', ...},
+                                {'etternavn': 'Gjuvsland', ...},
+                                ...],
+                     ...
+                     'tittel': 'Screening design for computer experiments: '
+                               'metamodelling of a deterministic mathematical '
+                               'model of the mammalian circadian clock'},
+      'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1002/cem.1363',
+                                               'hefte': '11-12',
+                                               'sideangivelse': {'sideFra': '738',
+                                                                 'sideTil': '747'},
+                                               'tidsskrift': {...
+                                                              'navn': 'Journal of '
+                                                                      'Chemometrics',
+                                                              ...},
+                                               'volum': '24'}}}]
 
-    Funding sources are in pubs["forskningsresultat"][i]["fellesdata"]["eksternprosjekt"].
+    Funding sources are in pubs[i]["fellesdata"]["eksternprosjekt"].
 
     >>> pprint(pubs_by("Jon Olav Vik", 2014, 2014))
-    {...
-     'forskningsresultat': [{'fellesdata': {'ar': '2014',
-                                            ...
-                                            'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
-                                                                 'id': 'SKGJ-MED-005'},
-                                                                {'finansieringskilde': {'kode': 'NFR', ...},
-                                                                 'id': '178901'},
-                                                                {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
-                                                                 'id': 'NN4653K'}],...
+    [{'fellesdata': {'ar': '2014',
+                     ...
+                     'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
+                                          'id': 'SKGJ-MED-005'},
+                                         {'finansieringskilde': {'kode': 'NFR', ...},
+                                          'id': '178901'},
+                                         {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
+                                          'id': 'NN4653K'}],...
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"
     url = base + urlencode(dict(lopenr=cpid, fra=fra, til=til, hovedkategori=hovedkategori, format="json"))
     logging.debug("Getting URL: " + url)
     pubs = requests.get(url).json()
-    return pubs
+    # This has dict_keys(['@xsi:noNamespaceSchemaLocation', 'generert', '@xmlns:xsi', 'forskningsresultat']),
+    # but we only need this one.
+    return pubs["forskningsresultat"]
 
 def citation(pub):
     """
     Citation of a single publication.
 
-    Example with a single author.
-
-    >>> pubs = pubs_by("Stig Omholt", 2013, 2013)
+    >>> pubs = pubs_by("Arne Gjuvsland", 2010, 2010)
+    >>> pubs.keys()
+    >>> for pub in pubs:
+    ...     print(citation(pub))
     """
 
 if __name__ == "__main__":

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -13,6 +13,7 @@ Info on transition from old to new API: http://www.cristin.no/om/aktuelt/aktuell
 """
 
 import requests
+import logging
 from urllib.parse import urlencode
 
 def cristin_person_id(author):
@@ -56,7 +57,7 @@ def pubs_by(author, fromyear="", toyear=""):
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"
     url = base + urlencode(dict(lopenr=cpid, fra=fromyear, til=toyear, format="json"))
-    print(url)
+    logging.debug("Getting URL: " + url)
     pubs = requests.get(url).json()
     return pubs
 

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -11,7 +11,10 @@ Old API docs: http://www.cristin.no/cristin/superbrukeropplaering/ws-dokumentasj
 Old XML schema: http://www.cristin.no/techdoc/xsd/resultater/1.0/
 Info on transition from old to new API: http://www.cristin.no/om/aktuelt/aktuelle-saker/2016/api-lansering.html
 """
+
+import argparse
 import operator
+import itertools
 import requests
 import logging
 from urllib.parse import urlencode
@@ -168,6 +171,20 @@ def format_author(a):
     initials = "".join(i[0] for i in given_names)
     return a["etternavn"] + " " + initials
 
+def deduplicate(pubs):
+    """
+    Remove duplicate publications from list.
+
+    >>> abg = pubs_by("Arne Gjuvsland", fra=2010, til=2014)
+    >>> jov = pubs_by("Jon Olav Vik", fra=2010, til=2014)
+    >>> len(abg)
+    17
+    >>> len(jov)
+    10
+    >>> len(deduplicate([abg, jov]))
+    19
+    """
+    return {p["id"]: p for p in itertools.chain(*pubs)}.values()
 
 def citation(pub, html=False):
     """
@@ -231,112 +248,20 @@ def bibliography_author(author, *args, **kwargs):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Compile HTML bibliography from CRISTIN for list of authors.")
+    parser.add_argument("-d", "--debug", help="log debug messages", action="store_true")
+    args = parser.parse_args()
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
 
-    with open("test.html", "w") as f:
-        f.write(bibliography_author("Jon Olav Vik"))
-
-    import sys
-    sys.exit(0)
-
-    # set up which user to search for will be passed to an ARGV in the future
-    # To be added later start year and end year
-    # start_year = 2015 end_year = 2015
-    name_of_user = "Jon Olav Vik"
-    # name_of_user = "Dag Inge Våge"
-    # name_of_user = "Sigbjørn Lien"
-    # name_of_user = "Arne Bjørke Gjuvsland"
-
-    # Initiate the url using pubs_by
-    data = pubs_by(name_of_user)
-
-    # Create a list containing all information for printing html code
-    html_codes_all = []
-
-    # Sort data according to year of publication, newest first
-    # noinspection PyShadowingNames
-    data_sort = sorted((data['forskningsresultat']), key=lambda k: k['fellesdata']['ar'], reverse=True)
-    # Start to iterate through all the "forskningsresultat" list
-    for i in data_sort:
-        # Create a string for name for each iteration
-        authors = ''
-        # Iterate through all persons in the project and create a name list
-        # Some instances are lists when multiple authors
-        if type(i['fellesdata']['person']) == list:
-            for k in i['fellesdata']['person']:
-                # Convert first names to uppercase letters only
-                Short_firstname = k['fornavn']
-                Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
-                # Append all the names to a string
-                authors += ((k['etternavn'] + ' ' + Uppercase_firstname) + ', ')
-            # Remove a comma and a white space at the end of strings
-            authors = authors[:-2]
-
-        # For instances when there is a single author
-        elif type(i['fellesdata']['person']) == dict:
-            Short_firstname = i['fellesdata']['person']['fornavn']
-            Uppercase_firstname = ''.join(c for c in Short_firstname if c.isupper())
-            # Append name to a string
-            authors = i['fellesdata']['person']['etternavn'] + ' ' + Uppercase_firstname
-
-        # Iterate through all keys in the categories.
-        for key, value in (i['kategoridata']).items():
-            # Start processing data based on known keys. This will be expanded later
-            if key == 'tidsskriftsartikkel':
-                tittel = i['fellesdata']['tittel']
-                year = i['fellesdata']['ar']
-                journal = '<em>' + i['kategoridata']['tidsskriftsartikkel']['tidsskrift']['navn'] + '</em>'
-
-                try:
-                    articlenr = i['kategoridata']['tidsskriftsartikkel']['artikkelnr']
-                except KeyError:
-                    articlenr = ''
-
-                try:
-                    volum = '<strong>(' + i['kategoridata']['tidsskriftsartikkel']['volum'] + ')</strong>'
-                except KeyError:
-                    volum = ''
-
-                try:
-                    DOI = 'http://dx.doi.org/' + i['kategoridata']['tidsskriftsartikkel']['doi']
-                except KeyError:
-                    DOI = ''
-
-                HTML_string = ('<p> ' + authors + ' (' + year + '). ' + tittel + ' ' + journal + ' ' + volum +
-                               ' ' + articlenr + ' ' + DOI + '</p>')
-                html_codes_all.append(HTML_string)
-
-                # Currently only working for Articles, codes below can be used to add more items.
-                # elif key == ( 'foredragPoster' ):
-                #     tittel = i['fellesdata']['tittel']
-                #     year = i['fellesdata']['ar']
-                #     #journal = '<em>'+i['kategoridata'][key]['navn']+'</em>' Wrokshop
-                # elif key == 'bokRapport':
-                #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-                #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
-                #
-                # elif key == 'bokRapportDel':
-                #     tittel = '<em>'+i['fellesdata']['tittel']+'</em>'
-                #     year = '<strong>'+i['fellesdata']['ar']+'</strong>'
-
-    html_str_start = """
-    <!DOCTYPE html>
-    <HTML>
-        <head>
-            <meta charset="utf-8">
-        </head>
-
-        <body>
-            <h1>References</h1>
+    authors = """
+    Jon Olav Vik
+    Dag Inge Våge
+    Sigbjørn Lien
+    Arne Bjørke Gjuvsland
     """
-
-    html_str_end = """
-        </body>
-    </HTML>
-    """
-
-    filename = name_of_user + '.html'
-    with open(filename, 'w+', encoding="utf-8") as myFile:
-        myFile.write(html_str_start)
-        for i in html_codes_all:
-            myFile.write('\t\t' + i + '\n')
-        myFile.write(html_str_end)
+    authors = [a.strip() for a in authors.strip().split("\n")]
+    pubs = [pubs_by(a, fra=2003, til=2015) for a in authors]
+    logging.debug("%s authors with a total of %s publications", len(authors), sum(len(p) for p in pubs))
+    pubs = deduplicate(pubs)
+    logging.debug("%s unique publications", len(pubs))

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -48,71 +48,19 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
     For now we return the full record, whose complex structure is documented at
     http://www.cristin.no/techdoc/xsd/resultater/1.0/
 
-    Example search that returns a single publication.
+    To make doctests reproducible we use pprint, which recursively sorts dict items.
 
-    >>> from pprint import pprint  # Deterministic printing of dict (recursively sorts items)
-    >>> p = pubs_by("Jon Olav Vik", 2014, 2014)
-    >>> len(p["forskningsresultat"])
-    1
-    >>> len(pubs_by("Jon Olav Vik", fra=1900, til=2015)["forskningsresultat"])
-    29
-    >>> sorted(p["forskningsresultat"][0].keys())
-    ['fellesdata', 'kategoridata']
-    >>> pprint(p)
-    {...
-     'forskningsresultat': [{'fellesdata': {'ar': '2014',
-                                            ...
-                                            'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
-                                                                 'id': 'SKGJ-MED-005'},
-                                                                {'finansieringskilde': {'kode': 'NFR', ...},
-                                                                 'id': '178901'},
-                                                                {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
-                                                                 'id': 'NN4653K'}],
-                                            ...
-                                            'id': '1161735',
-                                            ...
-                                            'person': [{'etternavn': 'Nordbø',
-                                                        'fornavn': 'Øyvind',
-                                                        ...
-                                                        'id': '317719',
-                                                        'rekkefolgenr': '1',
-                                                        'tilhorighet': {'sted': {'avdnr': '1', ...]},
-                                                       ...
-                                                       {'etternavn': 'Vik', ...}],
-                                            ...
-                                            'sammendrag': {'sprak': {...},
-                                                           'tekst': 'The mouse is '
-                                                                    'an important '
-                                                                    ...
-                                                                    'application.'},
-                                            ...
-                                            'tittel': 'A computational pipeline '
-                                                      'for quantification of mouse '
-                                                      'myocardial stiffness '
-                                                      'parameters'},
-                             'kategoridata': {'tidsskriftsartikkel': {'arstallOnline': '2014',
-                                                                      'arstallTrykket': '2014',
-                                                                      'doi': '10.1016/j.compbiomed.2014.07.013',
-                                                                      'sideangivelse': {'sideFra': '65',
-                                                                                        'sideTil': '75'},
-                                                                      'tidsskrift': {'id': '18057',
-                                                                                     'issn': '0010-4825',
-                                                                                     'kvalitetsniva': {'kode': '1',
-                                                                                                       ...},
-                                                                                     'navn': 'Computers '
-                                                                                             'in '
-                                                                                             'Biology '
-                                                                                             'and '
-                                                                                             'Medicine',
-                                                                                     ...},
-                                                                      'volum': '53'}}}],
-    ...}
+    >>> from pprint import pprint
 
-    Example search with two publications.
+    Arne Gjuvsland published two journal articles in 2010.
 
     >>> p = pubs_by("Arne Gjuvsland", 2010, 2010)
     >>> len(p["forskningsresultat"])
     2
+
+    Each item has "fellesdata" (shared among all publication types) and "kategoridata" (particular to journal articles).
+    Both are of interest.
+
     >>> sorted(p["forskningsresultat"][0].keys())
     ['fellesdata', 'kategoridata']
     >>> pprint(p)
@@ -144,7 +92,8 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
                                             ...
                                             'id': '771116',
                                             ...
-                                            'person': [{'etternavn': 'Tøndel', ...},
+                                            'person': [{'etternavn': 'Tøndel',
+                                                        'fornavn': 'Kristin', ...},
                                                        {'etternavn': 'Gjuvsland', ...},
                                                        ...],
                                             ...
@@ -162,6 +111,19 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
                                                                                      ...},
                                                                       'volum': '24'}}}],
     ...}
+
+    Funding sources are in pubs["forskningsresultat"][i]["fellesdata"]["eksternprosjekt"].
+
+    >>> pprint(pubs_by("Jon Olav Vik", 2014, 2014))
+    {...
+     'forskningsresultat': [{'fellesdata': {'ar': '2014',
+                                            ...
+                                            'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
+                                                                 'id': 'SKGJ-MED-005'},
+                                                                {'finansieringskilde': {'kode': 'NFR', ...},
+                                                                 'id': '178901'},
+                                                                {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
+                                                                 'id': 'NN4653K'}],...
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -41,22 +41,56 @@ def cristin_person_id(author):
             return None
 
 
-def pubs_by(author, fromyear="", toyear=""):
+def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
     """
     Get publications by author.
 
     For now we return the full record, whose complex structure is documented at
     http://www.cristin.no/techdoc/xsd/resultater/1.0/
 
-    The order of dict items is nondeterministic, which makes it tricky to write doctests...
-    The one below sometimes works, sometimes not.
-
-    >>> pubs_by("Jon Olav Vik")  # doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS
-    {...'forskningsresultat': [{'fellesdata': {'registrert': {'dato': '2016-05-25...
+    >>> from pprint import pprint
+    >>> pprint(pubs_by("Jon Olav Vik", 2009, 2009))
+    {...
+     'forskningsresultat': [{'fellesdata': {'ar': '2009',
+                                            ...
+                                            'id': '355297',
+                                            ...
+                                            'person': [{'etternavn': 'Godvik',
+                                                        'fornavn': 'Inger Maren '
+                                                                   'Rivrud',
+                                                        ...
+                                                        'id': '5361',
+                                                        'rekkefolgenr': '1',
+                                                        'tilhorighet': [{'sted': {'avdnr': '15', ...]},
+                                                       {'etternavn': 'Loe', ...},
+                                                       {'etternavn': 'Vik', ...},
+                                                       {'etternavn': 'Veiberg', ...},
+                                                       {'etternavn': 'Langvatn', ...},
+                                                       {'etternavn': 'Mysterud', ...}],
+                                            ...
+                                            'tittel': 'Temporal scales, '
+                                                      'trade-offs, and functional '
+                                                      'responses in red deer '
+                                                      'habitat selection'},
+                             'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1890/08-0576.1',
+                                                                      'hefte': '3',
+                                                                      'sideangivelse': {'sideFra': '699',
+                                                                                        'sideTil': '710'},
+                                                                      'tidsskrift': {'id': '185',
+                                                                                     'issn': '0012-9658',
+                                                                                     'kvalitetsniva': {'kode': '2',
+                                                                                                       'navn': 'Kvalitetsnivå '
+                                                                                                               '2',
+                                                                                                       'navnEngelsk': 'Quality '
+                                                                                                                      'level '
+                                                                                                                      '2'},
+                                                                                     'navn': 'Ecology', ...},
+                                                                      'volum': '90'}}}],
+     ...}
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"
-    url = base + urlencode(dict(lopenr=cpid, fra=fromyear, til=toyear, format="json"))
+    url = base + urlencode(dict(lopenr=cpid, fra=fra, til=til, hovedkategori=hovedkategori, format="json"))
     logging.debug("Getting URL: " + url)
     pubs = requests.get(url).json()
     return pubs

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -26,13 +26,13 @@ name_of_user = "Jon Olav Vik"
 def cristin_person_id(author):
     """
     Get CRISTIN person ID of author.
-    > cristin_person_id("Jon Olav Vik")
+    >>> cristin_person_id("Jon Olav Vik")
     22311
-    > cristin_person_id("22311")
+    >>> cristin_person_id("22311")
     22311
-    > cristin_person_id(22311)
+    >>> cristin_person_id(22311)
     22311
-    > cristin_person_id("Does not exist") is None
+    >>> cristin_person_id("Does not exist") is None
     True
     """
     try:
@@ -56,7 +56,7 @@ def pubs_by(author):
     The order of dict items is nondeterministic, which makes it tricky to write doctests...
     The one below sometimes works, sometimes not.
 
-    > pubs_by("Jon Olav Vik")  # doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS
+    >>> pubs_by("Jon Olav Vik")  # doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS
     {...'forskningsresultat': [{'fellesdata': {'registrert': {'dato': '2016-05-25...
     """
     cpid = cristin_person_id(author)

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -15,12 +15,21 @@ Info on transition from old to new API: http://www.cristin.no/om/aktuelt/aktuell
 import argparse
 import operator
 import itertools
+import os
+import tempfile
 import requests
 import logging
 from urllib.parse import urlencode
 from collections import defaultdict
 
+from joblib import Memory
 
+
+cachedir = os.path.join(tempfile.gettempdir(), "pubgrab_cache")
+mem = Memory(cachedir, verbose=0)
+
+
+@mem.cache
 def cristin_person_id(author):
     """
     Get CRISTIN person ID of author.
@@ -46,6 +55,7 @@ def cristin_person_id(author):
             return None
 
 
+@mem.cache
 def pubs_by(author, fra=1900, til=9999, hovedkategori="TIDSSKRIFTPUBL"):
     """
     Get publications by author.

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -57,78 +57,95 @@ def pubs_by(author, fra="", til="", hovedkategori="TIDSSKRIFTPUBL"):
     >>> p = pubs_by("Arne Gjuvsland", 2010, 2010)
     >>> len(p)
     2
-
-    Each item has "fellesdata" (shared among all publication types) and "kategoridata" (particular to journal articles).
-    Both are of interest.
-
-    >>> sorted(p[0].keys())
-    ['fellesdata', 'kategoridata']
     >>> pprint(p)
-    [{'fellesdata': {...
-                     'ar': '2010',
-                     ...
-                     'id': '769189',
-                     ...
-                     'person': [{'etternavn': 'Gjuvsland',
-                                 'fornavn': 'Arne Bjørke', ...},
-                                {'etternavn': 'Plahte', ...},
-                                {'etternavn': 'Ådnøy', ...},
-                                {'etternavn': 'Omholt', ...}],
-                     ...
-                     'tittel': 'Allele Interaction - Single Locus Genetics Meets '
-                               'Regulatory Biology'},
-      'kategoridata': {'tidsskriftsartikkel': {'artikkelnr': 'e9379',
-                                               'doi': '10.1371/journal.pone.0009379',
-                                               'hefte': '2',
-                                               'tidsskrift': {'@oaDoaj': 'true',
-                                                              'id': '435449',
-                                                              'issn': '1932-6203',
-                                                              'kvalitetsniva': {'kode': '1', ...},
-                                                              'navn': 'PLoS ONE',
-                                                              ...},
-                                               'volum': '5'}}},
-     {'fellesdata': {...
-                     'ar': '2010',
-                     ...
-                     'id': '771116',
-                     ...
-                     'person': [{'etternavn': 'Tøndel', ...},
-                                {'etternavn': 'Gjuvsland', ...},
-                                ...],
-                     ...
-                     'tittel': 'Screening design for computer experiments: '
-                               'metamodelling of a deterministic mathematical '
-                               'model of the mammalian circadian clock'},
-      'kategoridata': {'tidsskriftsartikkel': {'doi': '10.1002/cem.1363',
-                                               'hefte': '11-12',
-                                               'sideangivelse': {'sideFra': '738',
-                                                                 'sideTil': '747'},
-                                               'tidsskrift': {...
-                                                              'navn': 'Journal of '
-                                                                      'Chemometrics',
-                                                              ...},
-                                               'volum': '24'}}}]
+    [{...
+      'ar': '2010',
+      ...
+      'id': '769189',
+      ...
+      'kategori': {'hovedkategori': {'kode': 'TIDSSKRIFTPUBL',
+                                     'navn': 'Tidsskriftspublikasjon',
+                                     'navnEngelsk': 'Journal publication'},
+                   'underkategori': {'kode': 'ARTIKKEL',
+                                     'navn': 'Vitenskapelig artikkel',
+                                     'navnEngelsk': 'Academic article'}},
+      ...
+      'person': [{'etternavn': 'Gjuvsland',
+                  'fornavn': 'Arne Bjørke',
+                  'harFodselsnummer': 'true',
+                  'id': '7059',
+                  'rekkefolgenr': '1',
+                  'tilhorighet': {'sted': {'avdnr': '1', ...}}},
+                 {'etternavn': 'Plahte', ...},
+                 {'etternavn': 'Ådnøy', ...},
+                 {'etternavn': 'Omholt', ...}],
+      ...
+      'sammendrag': [{'sprak': {'kode': 'EN',
+                                'navn': 'Engelsk',
+                                'navnEngelsk': 'English'},
+                      'tekst': 'Conclusion/Significance: The concept of allele '
+                               'interaction refines single locus genetics ' ...},
+                     {'sprak': {'kode': 'EN',
+                                'navn': 'Engelsk',
+                                'navnEngelsk': 'English'},
+                      'tekst': 'Allele Interaction - Single Locus Genetics Meets '
+                               'Regulatory Biology'}],
+      'sprak': {'kode': 'EN', 'navn': 'Engelsk', 'navnEngelsk': 'English'},
+      'tidsskriftsartikkel': {'artikkelnr': 'e9379',
+                              'doi': '10.1371/journal.pone.0009379',
+                              'hefte': '2',
+                              'tidsskrift': {'@oaDoaj': 'true',
+                                             'id': '435449',
+                                             'issn': '1932-6203',
+                                             'kvalitetsniva': {'kode': '1', ...},
+                                             'navn': 'PLoS ONE',
+                                             ...},
+                              'volum': '5'},
+      'tittel': 'Allele Interaction - Single Locus Genetics Meets Regulatory '
+                'Biology'},
+     {...
+      'ar': '2010',
+      ...
+      'id': '771116',
+      ...
+      'person': [{'etternavn': 'Tøndel', ...},
+                 {'etternavn': 'Gjuvsland', ...},
+                 ...],
+      ...
+      'tidsskriftsartikkel': {'doi': '10.1002/cem.1363',
+                              'hefte': '11-12',
+                              'sideangivelse': {'sideFra': '738', 'sideTil': '747'},
+                              'tidsskrift': {'id': '5117',
+                                             'issn': '0886-9383',
+                                             'kvalitetsniva': {'kode': '1', ...},
+                                             'navn': 'Journal of Chemometrics',
+                                             ...},
+                              'volum': '24'},
+      'tittel': 'Screening design for computer experiments: metamodelling of a '
+                'deterministic mathematical model of the mammalian circadian '
+                'clock'}]
 
     Funding sources are in pubs[i]["fellesdata"]["eksternprosjekt"].
 
     >>> pprint(pubs_by("Jon Olav Vik", 2014, 2014))
-    [{'fellesdata': {'ar': '2014',
-                     ...
-                     'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
-                                          'id': 'SKGJ-MED-005'},
-                                         {'finansieringskilde': {'kode': 'NFR', ...},
-                                          'id': '178901'},
-                                         {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
-                                          'id': 'NN4653K'}],...
+    [{'ar': '2014',
+      ...
+      'eksternprosjekt': [{'finansieringskilde': {'kode': 'SKGJ', ...},
+                           'id': 'SKGJ-MED-005'},
+                          {'finansieringskilde': {'kode': 'NFR', ...},
+                           'id': '178901'},
+                          {'finansieringskilde': {'kode': 'NOTUR/NORSTORE', ...},
+                           'id': 'NN4653K'}],...
     """
     cpid = cristin_person_id(author)
     base = "http://www.cristin.no/ws/hentVarbeiderPerson?"
     url = base + urlencode(dict(lopenr=cpid, fra=fra, til=til, hovedkategori=hovedkategori, format="json"))
     logging.debug("Getting URL: " + url)
     pubs = requests.get(url).json()
-    # This has dict_keys(['@xsi:noNamespaceSchemaLocation', 'generert', '@xmlns:xsi', 'forskningsresultat']),
-    # but we only need this one.
-    return pubs["forskningsresultat"]
+    # pubs now has dict_keys(['@xsi:noNamespaceSchemaLocation', 'generert', '@xmlns:xsi', 'forskningsresultat'])
+    # Extract forskningsresultat then merge fellesdata and kategoridata so we return a list of one dict per publication
+    return [{**d["fellesdata"], **d["kategoridata"]} for d in pubs["forskningsresultat"]]
+
 
 def citation(pub):
     """

--- a/pubgrab.py
+++ b/pubgrab.py
@@ -60,6 +60,14 @@ def pubs_by(author, fromyear="", toyear=""):
     pubs = requests.get(url).json()
     return pubs
 
+def citation(pub):
+    """
+    Citation of a single publication.
+
+    Example with a single author.
+
+    >>> pubs = pubs_by("Stig Omholt", 2013, 2013)
+    """
 
 if __name__ == "__main__":
     # set up which user to search for will be passed to an ARGV in the future


### PR DESCRIPTION
This rewrite basically does the same as your main program, only split up into functions, with doctests that serve as documentation, runnable examples and unit testing.

I'm getting ready to apply this across many authors, so I added caching with joblib. The latest commit shows how unintrusive that was 8-)
